### PR TITLE
feat: download full CSVs

### DIFF
--- a/src/lib/components/ActionButton.svelte
+++ b/src/lib/components/ActionButton.svelte
@@ -1,46 +1,71 @@
 <script lang="ts">
-  import { Search, Download, BarChart, Clock, Link } from 'lucide-svelte';
-  
-  export let label: string;
-  export let icon: 'search' | 'download' | 'chart' | 'clock' | 'link' = 'search';
-  export let onClick: () => void;
-  export let disabled: boolean = false;
-  export let loading: boolean = false;
-  export let variant: 'primary' | 'secondary' = 'primary';
-  
-  // Determine the icon component to use
-  let IconComponent: typeof Search | typeof Download | typeof BarChart | typeof Clock | typeof Link;
-  
-  $: {
-    if (icon === 'search') IconComponent = Search;
-    else if (icon === 'download') IconComponent = Download;
-    else if (icon === 'chart') IconComponent = BarChart;
-    else if (icon === 'clock') IconComponent = Clock;
-    else if (icon === 'link') IconComponent = Link;
-  }
-  
-  // Determine the classes to use
-  $: buttonClasses = variant === 'primary' 
-    ? 'bg-neutral text-white border-neutral hover:text-neutral hover:bg-yellow hover:border-neutral'
-    : 'bg-base-100 text-neutral border-neutral hover:bg-base-200';
+	import { Search, Download, BarChart, Clock, Link } from 'lucide-svelte';
+
+	export let label: string;
+	export let icon: 'search' | 'download' | 'chart' | 'clock' | 'link' = 'search';
+	export let onClick: () => void | Promise<void>;
+	export let disabled: boolean = false;
+	export let loading: boolean = false;
+	export let variant: 'primary' | 'secondary' = 'primary';
+
+	// Local loading state for async handlers
+	let isExecuting = false;
+
+	// Handle click with async support
+	async function handleClick() {
+		if (disabled || loading || isExecuting) return;
+
+		try {
+			isExecuting = true;
+			const result = onClick();
+
+			// Check if onClick returned a promise
+			if (result instanceof Promise) {
+				await result;
+			}
+		} catch (error) {
+			console.error('Error in button click handler:', error);
+		} finally {
+			isExecuting = false;
+		}
+	}
+
+	// Determine the icon component to use
+	let IconComponent: typeof Search | typeof Download | typeof BarChart | typeof Clock | typeof Link;
+
+	$: {
+		if (icon === 'search') IconComponent = Search;
+		else if (icon === 'download') IconComponent = Download;
+		else if (icon === 'chart') IconComponent = BarChart;
+		else if (icon === 'clock') IconComponent = Clock;
+		else if (icon === 'link') IconComponent = Link;
+	}
+
+	// Determine the classes to use
+	$: buttonClasses =
+		variant === 'primary'
+			? 'bg-neutral text-white border-neutral hover:text-neutral hover:bg-yellow hover:border-neutral'
+			: 'bg-base-100 text-neutral border-neutral hover:bg-base-200';
 </script>
 
 <button
-  on:click={onClick}
-  disabled={disabled || loading}
-  class="px-3 py-1.5 text-xs flex items-center justify-center gap-1 border transition-colors {buttonClasses} disabled:opacity-50 disabled:cursor-not-allowed"
+	on:click={handleClick}
+	disabled={disabled || loading || isExecuting}
+	class="flex items-center justify-center gap-1 border px-3 py-1.5 text-xs transition-colors {buttonClasses} disabled:cursor-not-allowed disabled:opacity-50"
 >
-  {#if loading}
-    <div class="w-3 h-3 border-2 border-t-transparent border-current rounded-full animate-spin"></div>
-  {:else}
-    <svelte:component this={IconComponent} class="w-3 h-3" />
-  {/if}
-  {label}
+	{#if loading || isExecuting}
+		<div
+			class="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent"
+		></div>
+	{:else}
+		<svelte:component this={IconComponent} class="h-3 w-3" />
+	{/if}
+	{label}
 </button>
 
 <style>
-  /* Custom styles */
-  .btn-drop-shadow {
-    box-shadow: 2px 2px 0px rgba(0, 0, 0, 0.2);
-  }
-</style> 
+	/* Custom styles */
+	.btn-drop-shadow {
+		box-shadow: 2px 2px 0px rgba(0, 0, 0, 0.2);
+	}
+</style>

--- a/src/lib/components/ConfirmModal.svelte
+++ b/src/lib/components/ConfirmModal.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+	import { fade } from 'svelte/transition';
+	import { X, AlertCircle, Check, AlertOctagon } from 'lucide-svelte';
+	import { createEventDispatcher } from 'svelte';
+
+	// Props
+	export let title: string;
+	export let message: string;
+	export let type: 'info' | 'warning' | 'error' = 'info';
+	export let visible: boolean = false;
+	export let confirmLabel: string = 'Confirm';
+	export let cancelLabel: string = 'Cancel';
+	export let showCancel: boolean = true;
+
+	// Event handling
+	const dispatch = createEventDispatcher<{
+		confirm: void;
+		cancel: void;
+		close: void;
+	}>();
+
+	// Close modal and dispatch event
+	function close() {
+		dispatch('close');
+	}
+
+	// Confirm action and close
+	function confirm() {
+		dispatch('confirm');
+		close();
+	}
+
+	// Cancel action and close
+	function cancel() {
+		dispatch('cancel');
+		close();
+	}
+
+	// Handle backdrop click
+	function handleBackdropClick(event: MouseEvent) {
+		// Only close if clicking the backdrop directly, not the modal content
+		if (event.target === event.currentTarget) {
+			cancel();
+		}
+	}
+
+	// Handle keydown events for accessibility
+	function handleKeydown(event: KeyboardEvent) {
+		if (!visible) return;
+
+		if (event.key === 'Escape') {
+			cancel();
+		} else if (event.key === 'Enter') {
+			confirm();
+		}
+	}
+
+	// Get the icon and colors based on the modal type
+	$: typeIcon = type === 'error' ? AlertOctagon : type === 'warning' ? AlertCircle : Check;
+
+	$: typeColor = type === 'error' ? 'text-red' : type === 'warning' ? 'text-yellow' : 'text-blue';
+
+	$: typeColorBg =
+		type === 'error' ? 'border-red' : type === 'warning' ? 'border-yellow' : 'border-blue';
+</script>
+
+<svelte:window on:keydown={handleKeydown} />
+
+{#if visible}
+	<!-- Modal backdrop -->
+	<div
+		class="bg-neutral/50 fixed inset-0 z-50 flex items-center justify-center"
+		transition:fade={{ duration: 150 }}
+		on:click={handleBackdropClick}
+	>
+		<!-- Modal container -->
+		<div
+			class="bg-base-100 border-neutral relative mx-4 w-full max-w-md border shadow-sm"
+			transition:fade={{ duration: 150, delay: 50 }}
+		>
+			<!-- Modal header -->
+			<div class="border-neutral bg-base-200 flex items-center justify-between border-b p-3">
+				<h3 class="text-neutral flex items-center gap-2 text-xs font-bold uppercase">
+					<svelte:component this={typeIcon} class="h-3 w-3 {typeColor}" />
+					{title}
+				</h3>
+				<button
+					class="text-neutral hover:text-base-300 transition-colors"
+					on:click={cancel}
+					aria-label="Close modal"
+				>
+					<X class="h-3 w-3" />
+				</button>
+			</div>
+
+			<!-- Modal content -->
+			<div class="p-4">
+				<p class="text-xs" style="font-family: var(--font-ui);">
+					{message}
+				</p>
+			</div>
+
+			<!-- Modal footer -->
+			<div class="border-neutral flex justify-end gap-2 border-t p-3">
+				{#if showCancel}
+					<button
+						class="border-neutral bg-base-100 hover:bg-base-200 border px-3 py-1.5 text-xs transition-colors"
+						on:click={cancel}
+					>
+						{cancelLabel}
+					</button>
+				{/if}
+				<button
+					class="border-neutral bg-neutral hover:bg-blue hover:border-blue border px-3 py-1.5 text-xs text-white transition-colors"
+					on:click={confirm}
+				>
+					{confirmLabel}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/Results.svelte
+++ b/src/lib/components/Results.svelte
@@ -1,296 +1,312 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import { browser } from '$app/environment';
-  import { Database, BarChart, Clock, ChevronDown } from 'lucide-svelte';
-  import SortableTable from './SortableTable.svelte';
-  import Pagination from './Pagination.svelte';
-  import ActionButton from './ActionButton.svelte';
-  import LoadingGame from './LoadingGame.svelte';
-  import VisualizationPanel from './VisualizationPanel.svelte';
-  import { formatNumber } from '$lib/utils/formatUtils';
-  import { getAppContext } from '$lib/utils/context';
-  import { VIEW_MODES, allColumns, FEATURES } from '$lib/utils/constants';
-  import { notifications } from '$lib/utils/notificationUtils';
-  import { page } from '$app/stores';
-  
-  // Get the app context directly
-  const {
-    loading,
-    error,
-    dbReady,
-    viewMode,
-    results,
-    resultCount,
-    currentPage,
-    pageSize,
-    totalPages,
-    summaryResults,
-    timeAnalysisResults,
-    sortColumn,
-    sortDirection,
-    filters,
-    selectedColumns,
-    demographicColumns,
-    activityColumn,
-    aggregations, 
-    groupByColumns,
-    
-    downloadRawData,
-    downloadSummaryData,
-    downloadTimeAnalysisData,
-    changePage,
-    sortTimeAnalysisResults,
-  } = getAppContext();
-  
-  $: summaryMode = $viewMode === VIEW_MODES.SUMMARY;
-  $: timeAnalysisMode = $viewMode === VIEW_MODES.TIME_ANALYSIS;
-  $: rawDataMode = $viewMode === VIEW_MODES.RAW_DATA;
-  
-  let usingCachedData = false;
-  let loadingFromUrl = false;
-  
-  // Check if we're loading from a URL
-  $: loadingMessage = loadingFromUrl 
-    ? 'Executing query from URL...' 
-    : (usingCachedData 
-      ? 'Loading from cache...' 
-      : 'Loading data...');
-  
-  // Update loading message based on cache state
-  $: baseLoadingMessage = usingCachedData 
-    ? 'Loading from cache...' 
-    : ($dbReady ? 'Loading results...' : 'Initializing database... This may take a moment');
-    
-  // Get results message based on view mode
-  $: resultsMessage = $loading 
-    ? loadingMessage 
-    : (!currentResults.length)
-      ? ($dbReady ? 'No results found. Try adjusting your filters or aggregations.' : 'Initializing database...')
-      : (timeAnalysisMode)
-        ? `Showing time analysis results`
-        : (summaryMode)
-          ? `Showing ${formatNumber($summaryResults.length, { type: 'standard', decimals: 0 })} summary rows. `
-          : `Showing ${formatNumber(($currentPage - 1) * $pageSize + 1, { type: 'standard', decimals: 0 })}-${formatNumber(Math.min($currentPage * $pageSize, $resultCount), { type: 'standard', decimals: 0 })} of ${formatNumber($resultCount, { type: 'standard', decimals: 0 })} matching rows. `;
-            
-  // Add handlers for data events
-  function onCachedDataLoaded(event: Event) {
-    usingCachedData = true;
-    setTimeout(() => {
-      usingCachedData = false;
-    }, 2000); // Reset after 2 seconds
-  }
+	import { onMount } from 'svelte';
+	import { browser } from '$app/environment';
+	import { Database, BarChart, Clock, ChevronDown } from 'lucide-svelte';
+	import SortableTable from './SortableTable.svelte';
+	import Pagination from './Pagination.svelte';
+	import ActionButton from './ActionButton.svelte';
+	import LoadingGame from './LoadingGame.svelte';
+	import VisualizationPanel from './VisualizationPanel.svelte';
+	import { formatNumber } from '$lib/utils/formatUtils';
+	import { getAppContext } from '$lib/utils/context';
+	import { VIEW_MODES, allColumns, FEATURES } from '$lib/utils/constants';
+	import { notifications } from '$lib/utils/notificationUtils';
+	import { page } from '$app/stores';
 
-  function onUrlQueryDetected(event: Event) {
-    loadingFromUrl = true;
-  }
-  
-  function onUrlQueryCompleted(event: Event) {
-    loadingFromUrl = false;
-  }
-  
-  // Subscribe to custom events
-  onMount(() => {
-    if (browser) {
-      window.addEventListener('cached_data_loaded', onCachedDataLoaded);
-      window.addEventListener('url_query_processing', onUrlQueryDetected);
-      window.addEventListener('url_query_completed', onUrlQueryCompleted);
-      
-      // Check if URL has query parameters on load
-      if (FEATURES.ENABLE_URL_STATE && $page.url.searchParams.has('viewMode')) {
-        loadingFromUrl = true;
-      }
-      
-      return () => {
-        window.removeEventListener('cached_data_loaded', onCachedDataLoaded);
-        window.removeEventListener('url_query_processing', onUrlQueryDetected);
-        window.removeEventListener('url_query_completed', onUrlQueryCompleted);
-      };
-    }
-  });
-  
-  // Column type definition
-  type ColumnFormatType = 'standard' | 'lakhs' | 'millions' | 'billions' | 'compact' | 'percentage' ;
-  type ColumnDefinition = {
-    id: string;
-    label: string;
-    sortable?: boolean;
-    formatType?: ColumnFormatType;
-    formatOptions?: {
-      decimals?: number;
-      prefix?: string;
-      suffix?: string;
-    };
-  };
-  
-  // Helper functions for DRY code
-  function getColumnLabel(columnId: string): string {
-    return allColumns.find(c => c.id === columnId)?.label || columnId;
-  }
-  
-  function createColumnDefinition(columnId: string, sortable = true): ColumnDefinition {
-    // Get column type from allColumns
-    const columnInfo = allColumns.find(c => c.id === columnId);
-    const isNumeric = columnInfo?.type === 'number';
-    
-    // Special formatting for specific columns
-    let formatType: ColumnFormatType | undefined;
-    let formatOptions: { decimals?: number; prefix?: string; suffix?: string } | undefined;
-    
-    // Format settings based on column and context
-    if (isNumeric || columnId.includes('count') || columnId.includes('avg') || columnId.includes('sum') || columnId.includes('min') || columnId.includes('max')) {
-      if (columnId.includes('count') || columnId === 'activity_count') {
-        formatType = 'standard';
-        formatOptions = { decimals: 0 };
-      } else if (columnId.includes('avg') || columnId.includes('minutes')) {
-        formatType = 'standard';
-        formatOptions = { decimals: 1 };
-      } else if (columnId.includes('sum')) {
-        formatType = 'standard';
-        formatOptions = { decimals: 1 };
-      } else if (columnId === 'age' || columnId === 'household_size') {
-        formatType = 'standard';
-        formatOptions = { decimals: 0 };
-      }
-    }
-    
-    return {
-      id: columnId,
-      label: getColumnLabel(columnId),
-      sortable,
-      formatType,
-      formatOptions
-    };
-  }
-  
-  // Get download action, icon and determine if results exist based on view mode
-  $: downloadAction = timeAnalysisMode 
-    ? downloadTimeAnalysisData 
-    : (summaryMode ? downloadSummaryData : downloadRawData);
-  
-  $: resultsExist = timeAnalysisMode 
-    ? $timeAnalysisResults.length > 0
-    : (summaryMode ? $summaryResults.length > 0 : $results.length > 0);
-  
-  // Helper function to format time values with proper suffixes
-  function formatTimeValue(value: number, useCompact: boolean = false): string {
-    if (useCompact) {
-      // First format the number with compact notation
-      const formatted = formatNumber(value, {
-        type: 'compact',
-        decimals: 1
-      });
-      // Then add 'min' between the number and the unit suffix
-      return formatted.replace(/([0-9.]+)([KLM])?$/, '$1 min $2').trim();
-    } else {
-      return formatNumber(value, {
-        type: 'standard',
-        decimals: 1,
-        suffix: ' min'
-      });
-    }
-  }
-  
-  // Get current results based on view mode
-  $: currentResults = timeAnalysisMode 
-    ? $timeAnalysisResults.map(result => ({
-        ...result,
-        // Format total_minutes with both time and unit suffixes
-        total_minutes: formatTimeValue(result.total_minutes, true)
-      }))
-    : (summaryMode ? $summaryResults : $results);
-    
-  // Get columns based on the actual data structure in results
-  $: currentColumns = currentResults.length > 0
-    ? Object.keys(currentResults[0]).map(key => createColumnDefinition(key))
-    : [];
-    
-  // Get empty message based on view mode
-  $: emptyMessage = timeAnalysisMode
-    ? 'No time analysis results to display. Try adjusting your filters.'
-    : (summaryMode 
-      ? 'No summary results to display. Try adjusting your filters and aggregations.'
-      : 'No results to display. Adjust your filters and run the query.');
-      
-  // Get header icon and title based on view mode
-  $: headerIcon = timeAnalysisMode 
-    ? Clock 
-    : (summaryMode ? BarChart : Database);
-    
-  $: headerTitle = timeAnalysisMode 
-    ? 'Time Analysis' 
-    : (summaryMode ? 'Summary' : 'Raw Data');
-    
-  // Game state
-  let showGame = true;
-  let showGameComponent = true;
-  
-  // Load user preference from localStorage
-  onMount(() => {
-    if (browser) {
-      const hideGamePermanently = localStorage.getItem('hideLoadingGame') === 'true';
-      if (hideGamePermanently) {
-        showGame = false;
-        showGameComponent = false;
-      }
-    }
-  });
-  
-  function hideGamePermanently() {
-    if (browser) {
-      localStorage.setItem('hideLoadingGame', 'true');
-      showGame = false;
-      showGameComponent = false;
-    }
-  }
-  
-  function showLoadingSpinner() {
-    showGame = false;
-  }
+	// Get the app context directly
+	const {
+		loading,
+		error,
+		dbReady,
+		viewMode,
+		results,
+		resultCount,
+		currentPage,
+		pageSize,
+		totalPages,
+		summaryResults,
+		timeAnalysisResults,
+		sortColumn,
+		sortDirection,
+		filters,
+		selectedColumns,
+		demographicColumns,
+		activityColumn,
+		aggregations,
+		groupByColumns,
+
+		downloadRawData,
+		downloadSummaryData,
+		downloadTimeAnalysisData,
+		changePage,
+		sortTimeAnalysisResults
+	} = getAppContext();
+
+	$: summaryMode = $viewMode === VIEW_MODES.SUMMARY;
+	$: timeAnalysisMode = $viewMode === VIEW_MODES.TIME_ANALYSIS;
+	$: rawDataMode = $viewMode === VIEW_MODES.RAW_DATA;
+
+	let usingCachedData = false;
+	let loadingFromUrl = false;
+
+	// Check if we're loading from a URL
+	$: loadingMessage = loadingFromUrl
+		? 'Executing query from URL...'
+		: usingCachedData
+			? 'Loading from cache...'
+			: 'Loading data...';
+
+	// Update loading message based on cache state
+	$: baseLoadingMessage = usingCachedData
+		? 'Loading from cache...'
+		: $dbReady
+			? 'Loading results...'
+			: 'Initializing database... This may take a moment';
+
+	// Get results message based on view mode
+	$: resultsMessage = $loading
+		? loadingMessage
+		: !currentResults.length
+			? $dbReady
+				? 'No results found. Try adjusting your filters or aggregations.'
+				: 'Initializing database...'
+			: timeAnalysisMode
+				? `Showing time analysis results`
+				: summaryMode
+					? `Showing ${formatNumber($summaryResults.length, { type: 'standard', decimals: 0 })} summary rows. `
+					: `Showing ${formatNumber(($currentPage - 1) * $pageSize + 1, { type: 'standard', decimals: 0 })}-${formatNumber(Math.min($currentPage * $pageSize, $resultCount), { type: 'standard', decimals: 0 })} of ${formatNumber($resultCount, { type: 'standard', decimals: 0 })} matching rows. `;
+
+	// Add handlers for data events
+	function onCachedDataLoaded(event: Event) {
+		usingCachedData = true;
+		setTimeout(() => {
+			usingCachedData = false;
+		}, 2000); // Reset after 2 seconds
+	}
+
+	function onUrlQueryDetected(event: Event) {
+		loadingFromUrl = true;
+	}
+
+	function onUrlQueryCompleted(event: Event) {
+		loadingFromUrl = false;
+	}
+
+	// Subscribe to custom events
+	onMount(() => {
+		if (browser) {
+			window.addEventListener('cached_data_loaded', onCachedDataLoaded);
+			window.addEventListener('url_query_processing', onUrlQueryDetected);
+			window.addEventListener('url_query_completed', onUrlQueryCompleted);
+
+			// Check if URL has query parameters on load
+			if (FEATURES.ENABLE_URL_STATE && $page.url.searchParams.has('viewMode')) {
+				loadingFromUrl = true;
+			}
+
+			return () => {
+				window.removeEventListener('cached_data_loaded', onCachedDataLoaded);
+				window.removeEventListener('url_query_processing', onUrlQueryDetected);
+				window.removeEventListener('url_query_completed', onUrlQueryCompleted);
+			};
+		}
+	});
+
+	// Column type definition
+	type ColumnFormatType = 'standard' | 'lakhs' | 'millions' | 'billions' | 'compact' | 'percentage';
+	type ColumnDefinition = {
+		id: string;
+		label: string;
+		sortable?: boolean;
+		formatType?: ColumnFormatType;
+		formatOptions?: {
+			decimals?: number;
+			prefix?: string;
+			suffix?: string;
+		};
+	};
+
+	// Helper functions for DRY code
+	function getColumnLabel(columnId: string): string {
+		return allColumns.find((c) => c.id === columnId)?.label || columnId;
+	}
+
+	function createColumnDefinition(columnId: string, sortable = true): ColumnDefinition {
+		// Get column type from allColumns
+		const columnInfo = allColumns.find((c) => c.id === columnId);
+		const isNumeric = columnInfo?.type === 'number';
+
+		// Special formatting for specific columns
+		let formatType: ColumnFormatType | undefined;
+		let formatOptions: { decimals?: number; prefix?: string; suffix?: string } | undefined;
+
+		// Format settings based on column and context
+		if (
+			isNumeric ||
+			columnId.includes('count') ||
+			columnId.includes('avg') ||
+			columnId.includes('sum') ||
+			columnId.includes('min') ||
+			columnId.includes('max')
+		) {
+			if (columnId.includes('count') || columnId === 'activity_count') {
+				formatType = 'standard';
+				formatOptions = { decimals: 0 };
+			} else if (columnId.includes('avg') || columnId.includes('minutes')) {
+				formatType = 'standard';
+				formatOptions = { decimals: 1 };
+			} else if (columnId.includes('sum')) {
+				formatType = 'standard';
+				formatOptions = { decimals: 1 };
+			} else if (columnId === 'age' || columnId === 'household_size') {
+				formatType = 'standard';
+				formatOptions = { decimals: 0 };
+			}
+		}
+
+		return {
+			id: columnId,
+			label: getColumnLabel(columnId),
+			sortable,
+			formatType,
+			formatOptions
+		};
+	}
+
+	// Get download action, icon and determine if results exist based on view mode
+	$: downloadAction = timeAnalysisMode
+		? downloadTimeAnalysisData
+		: summaryMode
+			? downloadSummaryData
+			: downloadRawData;
+
+	$: resultsExist = timeAnalysisMode
+		? $timeAnalysisResults.length > 0
+		: summaryMode
+			? $summaryResults.length > 0
+			: $results.length > 0;
+
+	// Helper function to format time values with proper suffixes
+	function formatTimeValue(value: number, useCompact: boolean = false): string {
+		if (useCompact) {
+			// First format the number with compact notation
+			const formatted = formatNumber(value, {
+				type: 'compact',
+				decimals: 1
+			});
+			// Then add 'min' between the number and the unit suffix
+			return formatted.replace(/([0-9.]+)([KLM])?$/, '$1 min $2').trim();
+		} else {
+			return formatNumber(value, {
+				type: 'standard',
+				decimals: 1,
+				suffix: ' min'
+			});
+		}
+	}
+
+	// Get current results based on view mode
+	$: currentResults = timeAnalysisMode
+		? $timeAnalysisResults.map((result) => ({
+				...result,
+				// Format total_minutes with both time and unit suffixes
+				total_minutes: formatTimeValue(result.total_minutes, true)
+			}))
+		: summaryMode
+			? $summaryResults
+			: $results;
+
+	// Get columns based on the actual data structure in results
+	$: currentColumns =
+		currentResults.length > 0
+			? Object.keys(currentResults[0]).map((key) => createColumnDefinition(key))
+			: [];
+
+	// Get empty message based on view mode
+	$: emptyMessage = timeAnalysisMode
+		? 'No time analysis results to display. Try adjusting your filters.'
+		: summaryMode
+			? 'No summary results to display. Try adjusting your filters and aggregations.'
+			: 'No results to display. Adjust your filters and run the query.';
+
+	// Get header icon and title based on view mode
+	$: headerIcon = timeAnalysisMode ? Clock : summaryMode ? BarChart : Database;
+
+	$: headerTitle = timeAnalysisMode ? 'Time Analysis' : summaryMode ? 'Summary' : 'Raw Data';
+
+	// Game state
+	let showGame = true;
+	let showGameComponent = true;
+
+	// Load user preference from localStorage
+	onMount(() => {
+		if (browser) {
+			const hideGamePermanently = localStorage.getItem('hideLoadingGame') === 'true';
+			if (hideGamePermanently) {
+				showGame = false;
+				showGameComponent = false;
+			}
+		}
+	});
+
+	function hideGamePermanently() {
+		if (browser) {
+			localStorage.setItem('hideLoadingGame', 'true');
+			showGame = false;
+			showGameComponent = false;
+		}
+	}
+
+	function showLoadingSpinner() {
+		showGame = false;
+	}
 </script>
 
 <!-- Results panel -->
-<div class="flex flex-col h-full">
-  <!-- Mobile visualization - only shown on small screens -->
-   {#if $viewMode !== VIEW_MODES.RAW_DATA}
-  <details class="block lg:hidden mb-2 bg-base-100 border border-neutral group">
-    <summary class="p-3 font-semibold text-xs cursor-pointer border-b bg-base-200 border-neutral/20 flex items-center justify-between [&::-webkit-details-marker]:hidden">
-      Visualization
-      <ChevronDown class="w-3 h-3 transition-transform duration-200 group-open:rotate-180" />
-    </summary>
-    <div class="p-0">
-      <VisualizationPanel />
-    </div>
-  </details>
-  {/if}
-  
-  <!-- Desktop visualization is handled elsewhere in the layout -->
-  
-  <div class="bg-base-100 border border-neutral flex flex-col">
-    <!-- Results Header -->
-    <div class="p-2 flex justify-between items-start border-b border-neutral bg-base-200">
-      <div class="flex flex-col gap-1">
-        <h2 class="text-xs uppercase font-bold text-neutral flex items-center gap-1">
-          <svelte:component this={headerIcon} class="w-3 h-3" />
-          <span>{headerTitle}</span>
-        </h2>
-        <p class="text-xs text-base-300" style="font-family: var(--font-ui);">
-          {resultsMessage}
-        </p>
-      </div>
-      <div>
-        <div class="flex gap-1">
-          <ActionButton
-            onClick={downloadAction}
-            loading={$loading}
-            disabled={!resultsExist || $loading}
-            icon="download"
-            label="Download CSV"
-            variant="secondary"
-          />
-          
-          {#if resultsExist && FEATURES.ENABLE_URL_STATE}
-            <ActionButton
-              onClick={() => {
+<div class="flex h-full flex-col">
+	<!-- Mobile visualization - only shown on small screens -->
+	{#if $viewMode !== VIEW_MODES.RAW_DATA}
+		<details class="bg-base-100 border-neutral group mb-2 block border lg:hidden">
+			<summary
+				class="bg-base-200 border-neutral/20 flex cursor-pointer items-center justify-between border-b p-3 text-xs font-semibold [&::-webkit-details-marker]:hidden"
+			>
+				Visualization
+				<ChevronDown class="h-3 w-3 transition-transform duration-200 group-open:rotate-180" />
+			</summary>
+			<div class="p-0">
+				<VisualizationPanel />
+			</div>
+		</details>
+	{/if}
+
+	<!-- Desktop visualization is handled elsewhere in the layout -->
+
+	<div class="bg-base-100 border-neutral flex flex-col border">
+		<!-- Results Header -->
+		<div class="border-neutral bg-base-200 flex items-start justify-between border-b p-2">
+			<div class="flex flex-col gap-1">
+				<h2 class="text-neutral flex items-center gap-1 text-xs font-bold uppercase">
+					<svelte:component this={headerIcon} class="h-3 w-3" />
+					<span>{headerTitle}</span>
+				</h2>
+				<p class="text-base-300 text-xs" style="font-family: var(--font-ui);">
+					{resultsMessage}
+				</p>
+			</div>
+			<div>
+				<div class="flex gap-1">
+					<ActionButton
+						onClick={downloadAction}
+						loading={$loading}
+						disabled={!resultsExist || $loading}
+						icon="download"
+						label={rawDataMode ? 'Download Full Dataset' : 'Download CSV'}
+						variant="secondary"
+					/>
+
+					{#if resultsExist && FEATURES.ENABLE_URL_STATE}
+						<ActionButton
+							onClick={() => {
                 import('$lib/utils/urlStateUtils').then(module => {
                   const { serializeStateToURL } = module;
                   
@@ -321,49 +337,54 @@
                     });
                 });
               }}
-              icon="link"
-              label="Share"
-              variant="secondary"
-            />
-          {/if}
-        </div>
-      </div>
-    </div>
-    
-    <!-- Results Content -->
-    <div class="overflow-auto">
-      {#if showGameComponent}
-        <LoadingGame 
-          loading={$loading} 
-          dbReady={$dbReady} 
-          show={showGame}
-          on:hideGame={() => showGame = false}
-          on:hideGamePermanently={hideGamePermanently}
-          on:showLoadingSpinner={showLoadingSpinner}
-        />
-      {/if}
+							icon="link"
+							label="Share"
+							variant="secondary"
+						/>
+					{/if}
+				</div>
+			</div>
+		</div>
 
-      <div class:hidden={showGame && showGameComponent}>
-        <SortableTable 
-          columns={currentColumns}
-          rows={currentResults}
-          loading={$loading}
-          loadingMessage={loadingMessage}
-          emptyMessage={emptyMessage}
-          sortColumn={$sortColumn}
-          sortDirection={$sortDirection}
-          onSort={sortTimeAnalysisResults}
-          fadeInRows={rawDataMode}
-          showStripes={rawDataMode}
-          useInternalSort={true}
-        />
-        
-        {#if rawDataMode}
-          <Pagination currentPage={$currentPage} totalPages={$totalPages} loading={$loading} changePage={changePage} />
-        {/if}
-      </div>
-    </div>
-  </div>
+		<!-- Results Content -->
+		<div class="overflow-auto">
+			{#if showGameComponent}
+				<LoadingGame
+					loading={$loading}
+					dbReady={$dbReady}
+					show={showGame}
+					on:hideGame={() => (showGame = false)}
+					on:hideGamePermanently={hideGamePermanently}
+					on:showLoadingSpinner={showLoadingSpinner}
+				/>
+			{/if}
+
+			<div class:hidden={showGame && showGameComponent}>
+				<SortableTable
+					columns={currentColumns}
+					rows={currentResults}
+					loading={$loading}
+					{loadingMessage}
+					{emptyMessage}
+					sortColumn={$sortColumn}
+					sortDirection={$sortDirection}
+					onSort={sortTimeAnalysisResults}
+					fadeInRows={rawDataMode}
+					showStripes={rawDataMode}
+					useInternalSort={true}
+				/>
+
+				{#if rawDataMode}
+					<Pagination
+						currentPage={$currentPage}
+						totalPages={$totalPages}
+						loading={$loading}
+						{changePage}
+					/>
+				{/if}
+			</div>
+		</div>
+	</div>
 </div>
 
 <!-- <style>

--- a/src/lib/utils/csvUtils.ts
+++ b/src/lib/utils/csvUtils.ts
@@ -1,15 +1,17 @@
+import Papa from 'papaparse';
+
 // Function to download data as CSV
 export function downloadCSV(data: any[], filename: string): void {
   if (!data.length) return;
-  
+
   // Get all available columns from the first row
   const headers = Object.keys(data[0]);
   const csvRows = [headers.join(',')];
-  
+
   for (const row of data) {
     const values = headers.map(header => {
       const value = row[header];
-      
+
       // Handle different data types
       if (value === null || value === undefined) {
         return '';
@@ -23,14 +25,14 @@ export function downloadCSV(data: any[], filename: string): void {
         return value;
       }
     });
-    
+
     csvRows.push(values.join(','));
   }
-  
+
   const csvContent = csvRows.join('\n');
   const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
   const url = URL.createObjectURL(blob);
-  
+
   const link = document.createElement('a');
   link.setAttribute('href', url);
   link.setAttribute('download', filename);
@@ -43,14 +45,14 @@ export function downloadCSV(data: any[], filename: string): void {
 // Function to download raw data as CSV
 export function downloadRawDataCSV(results: any[], selectedColumns: string[]): void {
   if (!results.length) return;
-  
+
   const headers = selectedColumns.filter(col => col !== 'person_id');
   const csvRows = [headers.join(',')];
-  
+
   for (const row of results) {
     const values = headers.map(header => {
       const value = row[header];
-      
+
       // Handle different data types
       if (value === null || value === undefined) {
         return '';
@@ -64,14 +66,14 @@ export function downloadRawDataCSV(results: any[], selectedColumns: string[]): v
         return value;
       }
     });
-    
+
     csvRows.push(values.join(','));
   }
-  
+
   const csvContent = csvRows.join('\n');
   const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
   const url = URL.createObjectURL(blob);
-  
+
   const link = document.createElement('a');
   link.setAttribute('href', url);
   link.setAttribute('download', 'data-export.csv');
@@ -79,6 +81,372 @@ export function downloadRawDataCSV(results: any[], selectedColumns: string[]): v
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
+}
+
+// Function to download the full dataset as CSV (not paginated)
+export async function downloadFullRawDataCSV(
+  selectedColumns: string[],
+  filters: any[],
+  runQueryFn: Function
+): Promise<void> {
+  try {
+    // Show downloading notification
+    if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
+      window.dispatchEvent(new CustomEvent('notification', {
+        detail: { message: 'Preparing full dataset for download...', type: 'info' }
+      }));
+    }
+
+    // Run the query for all data (no pagination)
+    const { results } = await runQueryFn(
+      selectedColumns,
+      filters,
+      1, // Page 1
+      Number.MAX_SAFE_INTEGER // Effectively no limit
+    );
+
+    if (!results.length) {
+      if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
+        window.dispatchEvent(new CustomEvent('notification', {
+          detail: { message: 'No data to export', type: 'error' }
+        }));
+      }
+      return;
+    }
+
+    const headers = selectedColumns.filter(col => col !== 'person_id');
+    const csvRows = [headers.join(',')];
+
+    for (const row of results) {
+      const values = headers.map(header => {
+        const value = row[header];
+
+        // Handle different data types
+        if (value === null || value === undefined) {
+          return '';
+        } else if (typeof value === 'string') {
+          // Escape quotes and wrap in quotes if needed
+          return `"${value.replace(/"/g, '""')}"`;
+        } else if (typeof value === 'bigint') {
+          // Convert BigInt to string
+          return value.toString();
+        } else {
+          return value;
+        }
+      });
+
+      csvRows.push(values.join(','));
+    }
+
+    const csvContent = csvRows.join('\n');
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.setAttribute('href', url);
+    link.setAttribute('download', 'full-data-export.csv');
+    link.style.visibility = 'hidden';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    // Show success notification
+    if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
+      window.dispatchEvent(new CustomEvent('data_exported', {
+        detail: { type: 'Full raw data' }
+      }));
+    }
+  } catch (error) {
+    console.error('Error downloading full dataset:', error);
+
+    // Show error notification
+    if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
+      window.dispatchEvent(new CustomEvent('db_error', {
+        detail: { message: `Error exporting full dataset: ${error}` }
+      }));
+    }
+  }
+}
+
+// Function to download full raw data using DuckDB's native capabilities
+// This avoids browser memory limitations for large datasets
+export async function downloadFullDataWithDuckDB(
+  selectedColumns: string[],
+  filters: any[],
+  executeQueryFn: Function
+): Promise<void> {
+  try {
+    // Show downloading notification
+    if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
+      window.dispatchEvent(new CustomEvent('notification', {
+        detail: { message: 'Preparing full dataset for download...', type: 'info' }
+      }));
+    }
+
+    // Build WHERE clause from filters
+    const whereConditions: string[] = [];
+    filters.forEach(filter => {
+      if (filter.enabled && filter.value) {
+        // Simplified filter handling - this would need to match your actual query builder logic
+        if (filter.operator === '=') {
+          if (typeof filter.value === 'string') {
+            whereConditions.push(`${filter.column} = '${filter.value.replace(/'/g, "''")}'`);
+          } else {
+            whereConditions.push(`${filter.column} = ${filter.value}`);
+          }
+        } else if (filter.operator === '>') {
+          whereConditions.push(`${filter.column} > ${filter.value}`);
+        } else if (filter.operator === '<') {
+          whereConditions.push(`${filter.column} < ${filter.value}`);
+        } else {
+          if (typeof filter.value === 'string') {
+            whereConditions.push(`${filter.column} ${filter.operator} '${filter.value.replace(/'/g, "''")}'`);
+          } else {
+            whereConditions.push(`${filter.column} ${filter.operator} ${filter.value}`);
+          }
+        }
+      }
+    });
+
+    const whereClause = whereConditions.length > 0
+      ? `WHERE ${whereConditions.join(' AND ')}`
+      : '';
+
+    // Build and execute the query directly - stream to CSV
+    const query = `
+      SELECT ${selectedColumns.join(', ')}
+      FROM india_timeuse_survey
+      ${whereClause}
+    `;
+
+    // Execute the query to get results directly
+    const result = await executeQueryFn(query);
+
+    if (!result || (Array.isArray(result) && result.length === 0) ||
+      (result.toArray && result.toArray().length === 0)) {
+      if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
+        window.dispatchEvent(new CustomEvent('notification', {
+          detail: { message: 'No data to export', type: 'error' }
+        }));
+      }
+      return;
+    }
+
+    // Convert the Arrow result to CSV format
+    let csvContent;
+
+    // Check if the result is an Arrow table
+    if (result.toArray && typeof result.toArray === 'function') {
+      // Convert Arrow Table to array of objects for CSV
+      csvContent = tableToArrowCSV(result);
+    } else {
+      // Fallback if not an Arrow table
+      const rows = Array.isArray(result) ? result : [result];
+      csvContent = Papa.unparse(rows);
+    }
+
+    // Create and download the blob
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.setAttribute('href', url);
+    link.setAttribute('download', 'full-data-export.csv');
+    link.style.visibility = 'hidden';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    // Revoke the URL to free memory
+    setTimeout(() => {
+      URL.revokeObjectURL(url);
+    }, 100);
+
+    // Show success notification
+    if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
+      window.dispatchEvent(new CustomEvent('data_exported', {
+        detail: { type: 'Full raw data' }
+      }));
+    }
+  } catch (error) {
+    console.error('Error exporting data with DuckDB:', error);
+
+    // Show error notification with a helpful message about the size
+    if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
+      window.dispatchEvent(new CustomEvent('db_error', {
+        detail: {
+          message: `Error exporting dataset: ${error}. The dataset might be too large for browser-based export.`
+        }
+      }));
+    }
+  }
+}
+
+// Implements a chunked export approach for very large datasets
+// This exports data page by page to avoid memory issues
+export async function exportLargeDatasetInChunks(
+  selectedColumns: string[],
+  filters: any[],
+  totalCount: number,
+  runQueryFn: Function,
+  chunkSize: number = 10000
+): Promise<void> {
+  try {
+    // Show downloading notification
+    if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
+      window.dispatchEvent(new CustomEvent('notification', {
+        detail: { message: 'Starting progressive export of large dataset...', type: 'info' }
+      }));
+    }
+
+    // Create a blob parts array to store chunks
+    const blobParts: BlobPart[] = [];
+
+    // Add CSV header as first part
+    const header = selectedColumns.join(',') + '\n';
+    blobParts.push(header);
+
+    // Calculate total number of chunks
+    const totalChunks = Math.ceil(totalCount / chunkSize);
+
+    // Process each chunk
+    for (let chunk = 0; chunk < totalChunks; chunk++) {
+      const chunkPage = chunk + 1;
+
+      // Update progress notification every 3 chunks
+      if (chunk % 3 === 0 || chunk === totalChunks - 1) {
+        if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
+          const progressPct = Math.round(((chunk + 1) / totalChunks) * 100);
+          window.dispatchEvent(new CustomEvent('notification', {
+            detail: {
+              message: `Exporting data: ${progressPct}% complete (chunk ${chunk + 1}/${totalChunks})`,
+              type: 'info'
+            }
+          }));
+        }
+      }
+
+      // Fetch the current chunk
+      const { results } = await runQueryFn(
+        selectedColumns,
+        filters,
+        chunkPage,
+        chunkSize
+      );
+
+      if (!results.length) continue;
+
+      // Process this chunk's rows without headers
+      let chunkRows = '';
+
+      for (const row of results) {
+        const values = selectedColumns.map(header => {
+          const value = row[header];
+
+          // Handle different data types
+          if (value === null || value === undefined) {
+            return '';
+          } else if (typeof value === 'string') {
+            // Escape quotes and wrap in quotes if needed
+            return `"${value.replace(/"/g, '""')}"`;
+          } else if (typeof value === 'bigint') {
+            // Convert BigInt to string
+            return value.toString();
+          } else {
+            return value;
+          }
+        });
+
+        chunkRows += values.join(',') + '\n';
+      }
+
+      // Add this chunk to the blob parts
+      blobParts.push(chunkRows);
+    }
+
+    // Create the final blob with all chunks
+    const blob = new Blob(blobParts, { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+
+    // Trigger download
+    const link = document.createElement('a');
+    link.setAttribute('href', url);
+    link.setAttribute('download', 'full-data-export.csv');
+    link.style.visibility = 'hidden';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    // Clean up
+    setTimeout(() => {
+      URL.revokeObjectURL(url);
+    }, 100);
+
+    // Show success notification
+    if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
+      window.dispatchEvent(new CustomEvent('data_exported', {
+        detail: { type: 'Full dataset (chunked export)' }
+      }));
+    }
+  } catch (error) {
+    console.error('Error during chunked export:', error);
+
+    // Show error notification
+    if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
+      window.dispatchEvent(new CustomEvent('db_error', {
+        detail: { message: `Error during chunked export: ${error}` }
+      }));
+    }
+  }
+}
+
+// Convert Arrow table directly to CSV without intermediate JSON stage
+function tableToArrowCSV(table: any): string {
+  // Get column names from schema
+  const columns = table.schema.fields.map((f: any) => f.name);
+
+  // Create header row
+  const csvRows = [columns.join(',')];
+
+  // Convert rows to CSV
+  const rows = table.toArray();
+  for (const row of rows) {
+    const values = columns.map((col: string, idx: number) => {
+      const value = row[idx];
+
+      // Handle different data types
+      if (value === null || value === undefined) {
+        return '';
+      } else if (typeof value === 'string') {
+        // Escape quotes and wrap in quotes if needed
+        return `"${value.replace(/"/g, '""')}"`;
+      } else if (typeof value === 'bigint') {
+        // Convert BigInt to string
+        return value.toString();
+      } else {
+        return value;
+      }
+    });
+
+    csvRows.push(values.join(','));
+  }
+
+  return csvRows.join('\n');
+}
+
+// Helper function to convert table to CSV using Papaparse
+function tableToCSV(table: any): string {
+  // Convert Arrow Table to array of objects
+  const rows = table.toArray().map((row: any) => {
+    const obj: Record<string, any> = {};
+    table.schema.fields.forEach((field: any, i: number) => {
+      obj[field.name] = row[i];
+    });
+    return obj;
+  });
+
+  // Convert to CSV using Papaparse
+  return Papa.unparse(rows);
 }
 
 // Function to download summary data as CSV

--- a/src/lib/utils/csvUtils.ts
+++ b/src/lib/utils/csvUtils.ts
@@ -42,7 +42,7 @@ export function downloadCSV(data: any[], filename: string): void {
   document.body.removeChild(link);
 }
 
-// Function to download raw data as CSV
+// Function to download raw data as CSV (just for current page)
 export function downloadRawDataCSV(results: any[], selectedColumns: string[]): void {
   if (!results.length) return;
 
@@ -81,6 +81,321 @@ export function downloadRawDataCSV(results: any[], selectedColumns: string[]): v
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
+}
+
+// Function to download full raw data using DuckDB's native capabilities
+// This avoids browser memory limitations for large datasets
+export async function downloadFullDataWithDuckDB(
+  selectedColumns: string[],
+  filters: any[],
+  executeQueryFn: Function
+): Promise<void> {
+  try {
+    // Show downloading notification
+    if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
+      window.dispatchEvent(new CustomEvent('notification', {
+        detail: { message: 'Preparing dataset for download...', type: 'info' }
+      }));
+    }
+
+    // Build WHERE clause from filters
+    const whereConditions: string[] = [];
+    filters.forEach(filter => {
+      if (filter.enabled && filter.value) {
+        // Simplified filter handling - this would need to match your actual query builder logic
+        if (filter.operator === '=') {
+          if (typeof filter.value === 'string') {
+            whereConditions.push(`${filter.column} = '${filter.value.replace(/'/g, "''")}'`);
+          } else {
+            whereConditions.push(`${filter.column} = ${filter.value}`);
+          }
+        } else if (filter.operator === '>') {
+          whereConditions.push(`${filter.column} > ${filter.value}`);
+        } else if (filter.operator === '<') {
+          whereConditions.push(`${filter.column} < ${filter.value}`);
+        } else {
+          if (typeof filter.value === 'string') {
+            whereConditions.push(`${filter.column} ${filter.operator} '${filter.value.replace(/'/g, "''")}'`);
+          } else {
+            whereConditions.push(`${filter.column} ${filter.operator} ${filter.value}`);
+          }
+        }
+      }
+    });
+
+    const whereClause = whereConditions.length > 0
+      ? `WHERE ${whereConditions.join(' AND ')}`
+      : '';
+
+    // First, run a count query to see if we need chunking
+    const countQuery = `SELECT COUNT(*) as count FROM india_timeuse_survey ${whereClause}`;
+    const countResult = await executeQueryFn(countQuery);
+
+    let rowCount = 0;
+    if (countResult && countResult.toArray && typeof countResult.toArray === 'function') {
+      const countRows = countResult.toArray();
+      if (countRows.length > 0) {
+        rowCount = Number(countRows[0][0]); // Get count value
+      }
+    }
+
+    // Clear the count result to free memory
+    if (countResult && countResult.clear && typeof countResult.clear === 'function') {
+      countResult.clear();
+    }
+
+    // For small result sets (<10,000 rows), use direct query approach
+    if (rowCount < 10000) {
+      // Build and execute the query directly - stream to CSV
+      const query = `
+        SELECT ${selectedColumns.join(', ')}
+        FROM india_timeuse_survey
+        ${whereClause}
+        LIMIT 50000
+      `;
+
+      // Execute the query to get results directly
+      const result = await executeQueryFn(query);
+
+      try {
+        if (!result || (Array.isArray(result) && result.length === 0) ||
+          (result.toArray && result.toArray().length === 0)) {
+          if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
+            window.dispatchEvent(new CustomEvent('notification', {
+              detail: { message: 'No data to export', type: 'error' }
+            }));
+          }
+          return;
+        }
+
+        // Convert the Arrow result to CSV format and download
+        const csvContent = tableToArrowCSV(result);
+
+        // Clear the result to free memory
+        if (result && result.clear && typeof result.clear === 'function') {
+          result.clear();
+        }
+
+        downloadCSVBlob(csvContent, 'data-export.csv');
+
+        // Show success notification
+        if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
+          window.dispatchEvent(new CustomEvent('data_exported', {
+            detail: { type: 'Full raw data' }
+          }));
+        }
+      } finally {
+        // Always try to clean up
+        if (result && result.clear && typeof result.clear === 'function') {
+          result.clear();
+        }
+
+        // Force garbage collection if available
+        if (window.gc) {
+          try {
+            window.gc();
+          } catch (e) {
+            console.log('Manual garbage collection not supported');
+          }
+        }
+      }
+    } else {
+      // For larger datasets, recommend using the chunked approach
+      throw new Error(`Dataset is too large (${rowCount.toLocaleString()} rows). Using chunked export instead.`);
+    }
+  } catch (error) {
+    console.error('Error exporting data with DuckDB:', error);
+
+    // Show error notification with a helpful message about the size
+    if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
+      window.dispatchEvent(new CustomEvent('db_error', {
+        detail: {
+          message: `Error exporting dataset: ${error}. Using chunked export instead.`
+        }
+      }));
+    }
+
+    // Re-throw to trigger fallback to chunked export
+    throw error;
+  }
+}
+
+// Helper function to download a CSV blob
+function downloadCSVBlob(csvContent: string, filename: string): void {
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement('a');
+  link.setAttribute('href', url);
+  link.setAttribute('download', filename);
+  link.style.visibility = 'hidden';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+
+  // Revoke the URL to free memory
+  setTimeout(() => {
+    URL.revokeObjectURL(url);
+  }, 100);
+}
+
+// Implements a chunked export approach for very large datasets
+// This exports data page by page to avoid memory issues
+export async function exportLargeDatasetInChunks(
+  selectedColumns: string[],
+  filters: any[],
+  totalCount: number,
+  runQueryFn: Function,
+  chunkSize: number = 10000
+): Promise<void> {
+  try {
+    // Show downloading notification
+    if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
+      window.dispatchEvent(new CustomEvent('notification', {
+        detail: { message: 'Starting progressive export of large dataset...', type: 'info' }
+      }));
+    }
+
+    // Make sure we have a reasonable total count
+    if (!totalCount || totalCount <= 0) {
+      throw new Error('Invalid row count for chunked export');
+    }
+
+    // Adjust chunk size based on dataset size to prevent excessive chunking for small datasets
+    if (totalCount < 10000) {
+      chunkSize = totalCount;
+    } else if (totalCount < 50000) {
+      chunkSize = 5000;
+    }
+
+    // Create a blob parts array to store chunks
+    const blobParts: BlobPart[] = [];
+
+    // Add CSV header as first part
+    const header = selectedColumns.join(',') + '\n';
+    blobParts.push(header);
+
+    // Calculate total number of chunks
+    const totalChunks = Math.ceil(totalCount / chunkSize);
+
+    // Process each chunk
+    for (let chunk = 0; chunk < totalChunks; chunk++) {
+      const chunkPage = chunk + 1;
+
+      // Update progress notification every few chunks
+      if (chunk % 3 === 0 || chunk === totalChunks - 1) {
+        if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
+          const progressPct = Math.round(((chunk + 1) / totalChunks) * 100);
+          window.dispatchEvent(new CustomEvent('notification', {
+            detail: {
+              message: `Exporting data: ${progressPct}% complete (chunk ${chunk + 1}/${totalChunks})`,
+              type: 'info'
+            }
+          }));
+        }
+      }
+
+      try {
+        // Fetch the current chunk
+        const { results } = await runQueryFn(
+          selectedColumns,
+          filters,
+          chunkPage,
+          chunkSize
+        );
+
+        if (!results || !results.length) continue;
+
+        // Process this chunk's rows without headers
+        let chunkRows = '';
+
+        for (const row of results) {
+          const values = selectedColumns.map(header => {
+            const value = row[header];
+
+            // Handle different data types
+            if (value === null || value === undefined) {
+              return '';
+            } else if (typeof value === 'string') {
+              // Escape quotes and wrap in quotes if needed
+              return `"${value.replace(/"/g, '""')}"`;
+            } else if (typeof value === 'bigint') {
+              // Convert BigInt to string
+              return value.toString();
+            } else {
+              return value;
+            }
+          });
+
+          chunkRows += values.join(',') + '\n';
+        }
+
+        // Add this chunk to the blob parts
+        blobParts.push(chunkRows);
+
+        // Explicitly clear references to help garbage collection
+        chunkRows = '';
+      } catch (chunkError) {
+        console.error(`Error processing chunk ${chunkPage}:`, chunkError);
+        if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
+          window.dispatchEvent(new CustomEvent('notification', {
+            detail: {
+              message: `Error processing chunk ${chunkPage}: ${chunkError}. The export may be incomplete.`,
+              type: 'warning'
+            }
+          }));
+        }
+      }
+
+      // Force a small delay between chunks to allow UI updates and garbage collection
+      await new Promise(resolve => setTimeout(resolve, 50));
+    }
+
+    // Create the final blob with all chunks
+    const blob = new Blob(blobParts, { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+
+    // Trigger download
+    const link = document.createElement('a');
+    link.setAttribute('href', url);
+    link.setAttribute('download', 'full-data-export.csv');
+    link.style.visibility = 'hidden';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    // Clean up
+    blobParts.length = 0; // Clear array
+
+    setTimeout(() => {
+      URL.revokeObjectURL(url);
+
+      // Force garbage collection if available
+      if (window.gc) {
+        try {
+          window.gc();
+        } catch (e) {
+          console.log('Manual garbage collection not supported');
+        }
+      }
+    }, 100);
+
+    // Show success notification
+    if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
+      window.dispatchEvent(new CustomEvent('data_exported', {
+        detail: { type: 'Full dataset (chunked export)' }
+      }));
+    }
+  } catch (error) {
+    console.error('Error during chunked export:', error);
+
+    // Show error notification
+    if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
+      window.dispatchEvent(new CustomEvent('db_error', {
+        detail: { message: `Error during chunked export: ${error}` }
+      }));
+    }
+  }
 }
 
 // Function to download the full dataset as CSV (not paginated)
@@ -168,180 +483,27 @@ export async function downloadFullRawDataCSV(
   }
 }
 
-// Function to download full raw data using DuckDB's native capabilities
-// This avoids browser memory limitations for large datasets
-export async function downloadFullDataWithDuckDB(
-  selectedColumns: string[],
-  filters: any[],
-  executeQueryFn: Function
-): Promise<void> {
+// Convert Arrow table directly to CSV without intermediate JSON stage
+function tableToArrowCSV(table: any): string {
   try {
-    // Show downloading notification
-    if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
-      window.dispatchEvent(new CustomEvent('notification', {
-        detail: { message: 'Preparing full dataset for download...', type: 'info' }
-      }));
-    }
+    // Get column names from schema
+    const columns = table.schema.fields.map((f: any) => f.name);
 
-    // Build WHERE clause from filters
-    const whereConditions: string[] = [];
-    filters.forEach(filter => {
-      if (filter.enabled && filter.value) {
-        // Simplified filter handling - this would need to match your actual query builder logic
-        if (filter.operator === '=') {
-          if (typeof filter.value === 'string') {
-            whereConditions.push(`${filter.column} = '${filter.value.replace(/'/g, "''")}'`);
-          } else {
-            whereConditions.push(`${filter.column} = ${filter.value}`);
-          }
-        } else if (filter.operator === '>') {
-          whereConditions.push(`${filter.column} > ${filter.value}`);
-        } else if (filter.operator === '<') {
-          whereConditions.push(`${filter.column} < ${filter.value}`);
-        } else {
-          if (typeof filter.value === 'string') {
-            whereConditions.push(`${filter.column} ${filter.operator} '${filter.value.replace(/'/g, "''")}'`);
-          } else {
-            whereConditions.push(`${filter.column} ${filter.operator} ${filter.value}`);
-          }
-        }
-      }
-    });
+    // Create header row
+    const csvRows = [columns.join(',')];
 
-    const whereClause = whereConditions.length > 0
-      ? `WHERE ${whereConditions.join(' AND ')}`
-      : '';
+    // Get rows
+    const rows = table.toArray();
 
-    // Build and execute the query directly - stream to CSV
-    const query = `
-      SELECT ${selectedColumns.join(', ')}
-      FROM india_timeuse_survey
-      ${whereClause}
-    `;
+    // Convert rows to CSV in batches to reduce memory pressure
+    const batchSize = 1000;
+    for (let i = 0; i < rows.length; i += batchSize) {
+      const batch = rows.slice(i, i + batchSize);
+      let batchText = '';
 
-    // Execute the query to get results directly
-    const result = await executeQueryFn(query);
-
-    if (!result || (Array.isArray(result) && result.length === 0) ||
-      (result.toArray && result.toArray().length === 0)) {
-      if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
-        window.dispatchEvent(new CustomEvent('notification', {
-          detail: { message: 'No data to export', type: 'error' }
-        }));
-      }
-      return;
-    }
-
-    // Convert the Arrow result to CSV format
-    let csvContent;
-
-    // Check if the result is an Arrow table
-    if (result.toArray && typeof result.toArray === 'function') {
-      // Convert Arrow Table to array of objects for CSV
-      csvContent = tableToArrowCSV(result);
-    } else {
-      // Fallback if not an Arrow table
-      const rows = Array.isArray(result) ? result : [result];
-      csvContent = Papa.unparse(rows);
-    }
-
-    // Create and download the blob
-    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-    const url = URL.createObjectURL(blob);
-
-    const link = document.createElement('a');
-    link.setAttribute('href', url);
-    link.setAttribute('download', 'full-data-export.csv');
-    link.style.visibility = 'hidden';
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-
-    // Revoke the URL to free memory
-    setTimeout(() => {
-      URL.revokeObjectURL(url);
-    }, 100);
-
-    // Show success notification
-    if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
-      window.dispatchEvent(new CustomEvent('data_exported', {
-        detail: { type: 'Full raw data' }
-      }));
-    }
-  } catch (error) {
-    console.error('Error exporting data with DuckDB:', error);
-
-    // Show error notification with a helpful message about the size
-    if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
-      window.dispatchEvent(new CustomEvent('db_error', {
-        detail: {
-          message: `Error exporting dataset: ${error}. The dataset might be too large for browser-based export.`
-        }
-      }));
-    }
-  }
-}
-
-// Implements a chunked export approach for very large datasets
-// This exports data page by page to avoid memory issues
-export async function exportLargeDatasetInChunks(
-  selectedColumns: string[],
-  filters: any[],
-  totalCount: number,
-  runQueryFn: Function,
-  chunkSize: number = 10000
-): Promise<void> {
-  try {
-    // Show downloading notification
-    if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
-      window.dispatchEvent(new CustomEvent('notification', {
-        detail: { message: 'Starting progressive export of large dataset...', type: 'info' }
-      }));
-    }
-
-    // Create a blob parts array to store chunks
-    const blobParts: BlobPart[] = [];
-
-    // Add CSV header as first part
-    const header = selectedColumns.join(',') + '\n';
-    blobParts.push(header);
-
-    // Calculate total number of chunks
-    const totalChunks = Math.ceil(totalCount / chunkSize);
-
-    // Process each chunk
-    for (let chunk = 0; chunk < totalChunks; chunk++) {
-      const chunkPage = chunk + 1;
-
-      // Update progress notification every 3 chunks
-      if (chunk % 3 === 0 || chunk === totalChunks - 1) {
-        if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
-          const progressPct = Math.round(((chunk + 1) / totalChunks) * 100);
-          window.dispatchEvent(new CustomEvent('notification', {
-            detail: {
-              message: `Exporting data: ${progressPct}% complete (chunk ${chunk + 1}/${totalChunks})`,
-              type: 'info'
-            }
-          }));
-        }
-      }
-
-      // Fetch the current chunk
-      const { results } = await runQueryFn(
-        selectedColumns,
-        filters,
-        chunkPage,
-        chunkSize
-      );
-
-      if (!results.length) continue;
-
-      // Process this chunk's rows without headers
-      let chunkRows = '';
-
-      for (const row of results) {
-        const values = selectedColumns.map(header => {
-          const value = row[header];
+      for (const row of batch) {
+        const values = columns.map((col: string, idx: number) => {
+          const value = row[idx];
 
           // Handle different data types
           if (value === null || value === undefined) {
@@ -357,81 +519,17 @@ export async function exportLargeDatasetInChunks(
           }
         });
 
-        chunkRows += values.join(',') + '\n';
+        batchText += values.join(',') + '\n';
       }
 
-      // Add this chunk to the blob parts
-      blobParts.push(chunkRows);
+      csvRows.push(batchText);
     }
 
-    // Create the final blob with all chunks
-    const blob = new Blob(blobParts, { type: 'text/csv;charset=utf-8;' });
-    const url = URL.createObjectURL(blob);
-
-    // Trigger download
-    const link = document.createElement('a');
-    link.setAttribute('href', url);
-    link.setAttribute('download', 'full-data-export.csv');
-    link.style.visibility = 'hidden';
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-
-    // Clean up
-    setTimeout(() => {
-      URL.revokeObjectURL(url);
-    }, 100);
-
-    // Show success notification
-    if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
-      window.dispatchEvent(new CustomEvent('data_exported', {
-        detail: { type: 'Full dataset (chunked export)' }
-      }));
-    }
+    return csvRows.join('');
   } catch (error) {
-    console.error('Error during chunked export:', error);
-
-    // Show error notification
-    if (typeof window !== 'undefined' && 'dispatchEvent' in window) {
-      window.dispatchEvent(new CustomEvent('db_error', {
-        detail: { message: `Error during chunked export: ${error}` }
-      }));
-    }
+    console.error('Error converting Arrow table to CSV:', error);
+    throw error;
   }
-}
-
-// Convert Arrow table directly to CSV without intermediate JSON stage
-function tableToArrowCSV(table: any): string {
-  // Get column names from schema
-  const columns = table.schema.fields.map((f: any) => f.name);
-
-  // Create header row
-  const csvRows = [columns.join(',')];
-
-  // Convert rows to CSV
-  const rows = table.toArray();
-  for (const row of rows) {
-    const values = columns.map((col: string, idx: number) => {
-      const value = row[idx];
-
-      // Handle different data types
-      if (value === null || value === undefined) {
-        return '';
-      } else if (typeof value === 'string') {
-        // Escape quotes and wrap in quotes if needed
-        return `"${value.replace(/"/g, '""')}"`;
-      } else if (typeof value === 'bigint') {
-        // Convert BigInt to string
-        return value.toString();
-      } else {
-        return value;
-      }
-    });
-
-    csvRows.push(values.join(','));
-  }
-
-  return csvRows.join('\n');
 }
 
 // Helper function to convert table to CSV using Papaparse
@@ -457,4 +555,11 @@ export function downloadSummaryCSV(summaryResults: any[]): void {
 // Function to download time analysis data as CSV
 export function downloadTimeAnalysisCSV(timeAnalysisResults: any[]): void {
   downloadCSV(timeAnalysisResults, 'time-analysis-export.csv');
+}
+
+// For TypeScript
+declare global {
+  interface Window {
+    gc?: () => void;
+  }
 } 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,67 +1,97 @@
 <script lang="ts">
-  import Seo from '$lib/components/SEO.svelte';
-  import Sidebar from '$lib/components/Sidebar.svelte';
-  import Results from '$lib/components/Results.svelte';
-  import About from '$lib/components/About.svelte';
-  import VisualizationPanel from '$lib/components/VisualizationPanel.svelte';
-  import { notifications } from '$lib/utils/notificationUtils';
-  import { getAppContext } from '$lib/utils/context';
-  import { VIEW_MODES } from '$lib/utils/constants';
-  
-  const { viewMode } = getAppContext();
-  
-  function handleComponentError(component: string, error: unknown): void {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    notifications.technicalError(`${component} error: ${errorMessage}`);
-  }
+	import Seo from '$lib/components/SEO.svelte';
+	import Sidebar from '$lib/components/Sidebar.svelte';
+	import Results from '$lib/components/Results.svelte';
+	import About from '$lib/components/About.svelte';
+	import VisualizationPanel from '$lib/components/VisualizationPanel.svelte';
+	import { notifications } from '$lib/utils/notificationUtils';
+	import { getAppContext, exportConfirmDialog } from '$lib/utils/context';
+	import { browser } from '$app/environment';
+	import { onMount } from 'svelte';
+	import { VIEW_MODES } from '$lib/utils/constants';
+	import ConfirmModal from '$lib/components/ConfirmModal.svelte';
+
+	const { viewMode } = getAppContext();
+
+	function handleComponentError(component: string, error: unknown): void {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		notifications.technicalError(`${component} error: ${errorMessage}`);
+	}
+
+	// Handle modal confirm/cancel events
+	function handleConfirmExport() {
+		if ($exportConfirmDialog.onConfirm) {
+			$exportConfirmDialog.onConfirm();
+		}
+
+		// Close the dialog
+		exportConfirmDialog.update((dialog) => ({
+			...dialog,
+			visible: false
+		}));
+	}
+
+	function handleCancelExport() {
+		// Just close the dialog
+		exportConfirmDialog.update((dialog) => ({
+			...dialog,
+			visible: false
+		}));
+	}
 </script>
 
 <Seo />
 
-<div class="grid grid-cols-1 lg:grid-cols-4 gap-4 h-full overflow-y-clip">
-  {#if $viewMode !== VIEW_MODES.ABOUT}
-    <!-- Sidebar on the left column -->
-    <div class="flex flex-col gap-4 lg:h-[calc(96svh-6.2rem)]">
-      <div class="flex-1 h-1/2">
-        <svelte:boundary onerror={(error: unknown, reset: () => void) => handleComponentError('Sidebar', error)}>
-          <Sidebar />
-          
-          {#snippet failed(error, reset)}
-            <div class="bg-base-200 p-4 rounded-md text-sm">
-              <p class="mb-2">Filter panel could not be displayed</p>
-              <button 
-                class="text-xs bg-neutral text-white px-2 py-1 rounded-sm" 
-                on:click={reset}
-              >
-                Try again
-              </button>
-            </div>
-          {/snippet}
-        </svelte:boundary>
-      </div>
-      <!-- Visualization panel under sidebar on desktop only -->
-      {#if $viewMode !== VIEW_MODES.ABOUT && $viewMode !== VIEW_MODES.RAW_DATA}
-        <div class="hidden lg:block flex-1 h-1/2 mb-4">
-          <VisualizationPanel />
-        </div>
-      {:else}
-        <div class="hidden -z-1 h-1/2 flex-1 lg:block mb-4">
+<div class="grid h-full grid-cols-1 gap-4 overflow-y-clip lg:grid-cols-4">
+	{#if $viewMode !== VIEW_MODES.ABOUT}
+		<!-- Sidebar on the left column -->
+		<div class="flex flex-col gap-4 lg:h-[calc(96svh-6.2rem)]">
+			<div class="h-1/2 flex-1">
+				<svelte:boundary
+					onerror={(error: unknown, reset: () => void) => handleComponentError('Sidebar', error)}
+				>
+					<Sidebar />
 
-        </div>
-      {/if}
-    </div>
-    
-    <!-- Results on the right column -->
-    <div class="lg:col-span-3 h-full">
-     
-        <Results />
-        
-      
-    </div>
-  {:else}
-    <!-- About view takes full width -->
-    <div class="lg:col-span-4 mb-4 h-full">
-      <About />
-    </div>
-  {/if}
+					{#snippet failed(error, reset)}
+						<div class="bg-base-200 rounded-md p-4 text-sm">
+							<p class="mb-2">Filter panel could not be displayed</p>
+							<button class="bg-neutral rounded-sm px-2 py-1 text-xs text-white" on:click={reset}>
+								Try again
+							</button>
+						</div>
+					{/snippet}
+				</svelte:boundary>
+			</div>
+			<!-- Visualization panel under sidebar on desktop only -->
+			{#if $viewMode !== VIEW_MODES.ABOUT && $viewMode !== VIEW_MODES.RAW_DATA}
+				<div class="mb-4 hidden h-1/2 flex-1 lg:block">
+					<VisualizationPanel />
+				</div>
+			{:else}
+				<div class="-z-1 mb-4 hidden h-1/2 flex-1 lg:block"></div>
+			{/if}
+		</div>
+
+		<!-- Results on the right column -->
+		<div class="h-full lg:col-span-3">
+			<Results />
+		</div>
+	{:else}
+		<!-- About view takes full width -->
+		<div class="mb-4 h-full lg:col-span-4">
+			<About />
+		</div>
+	{/if}
 </div>
+
+<!-- Export confirmation modal -->
+<ConfirmModal
+	visible={$exportConfirmDialog.visible}
+	title={$exportConfirmDialog.title}
+	message={$exportConfirmDialog.message}
+	type={$exportConfirmDialog.type}
+	confirmLabel="Export"
+	cancelLabel="Cancel"
+	on:confirm={handleConfirmExport}
+	on:cancel={handleCancelExport}
+/>


### PR DESCRIPTION
Previously, in the raw data view, only the current page was exported and not the actual full dataset. This is now fixed by allowing full dataset exports in raw data view. 

Since these could be a large number of rows, data is chunked appropriately and joined during export. This works well in my tests for even the full dataset.

![image](https://github.com/user-attachments/assets/de1e6875-4e56-4c45-8a8f-cde8aba6a9aa)

Closes #2 


## Testing

If you can try this in the raw data view:
- Export a view with more than 250,000 rows. 
- Export a smaller view with around 50,000 rows.